### PR TITLE
Update pep8-naming to version 0.12.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: True  # [py<37]
+  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   number: 0
 
@@ -22,7 +24,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.7
     - flake8 >=3.9.1
     - flake8-polyfill >=1.0.2,<2
 
@@ -30,6 +32,7 @@ test:
   imports:
     - pep8ext_naming
   requires:
+    - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ about:
   license_file: LICENSE
   summary: 'Plug-in for flake 8 to check the PEP-8 naming conventions'
   dev_url: https://github.com/PyCQA/pep8-naming
+  doc_url: https://pypi.org/project/pep8-naming/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pep8-naming" %}
-{% set version = "0.12.0" %}
-{% set sha256 = "1f9a3ecb2f3fd83240fd40afdd70acc89695c49c333413e49788f93b61827e12" %}
+{% set version = "0.12.1" %}
+{% set sha256 = "bb2455947757d162aa4cad55dba4ce029005cd1692f2899a21d51d8630ca7841" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  skip: True  # [py<36]
-  noarch: python
+  # skip: True  # [py<36]
+  # noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   number: 0
 
@@ -24,7 +24,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - flake8 >=3.9.1
     - flake8-polyfill >=1.0.2,<2
 
@@ -32,7 +32,7 @@ test:
   imports:
     - pep8ext_naming
   requires:
-    - python <3.10
+    #  - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  skip: True  # [py<37]
+  skip: True  # [py<36]
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   number: 0
@@ -24,7 +24,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.7
+    - python >=3.6
     - flake8 >=3.9.1
     - flake8-polyfill >=1.0.2,<2
 


### PR DESCRIPTION
  `pep8-naming` version `0.12.1`
1. check the upstream
    https://github.com/PyCQA/pep8-naming/tree/0.12.1

2. check the pinnings
    https://github.com/PyCQA/pep8-naming/blob/0.12.1/tox.ini
    https://github.com/PyCQA/pep8-naming/blob/0.12.1/setup.py
    https://github.com/PyCQA/pep8-naming/blob/0.12.1/setup.cfg
    https://github.com/PyCQA/pep8-naming/blob/0.12.1/run_tests.py
    
3. check the changelogs
    https://github.com/PyCQA/pep8-naming/blob/0.12.1/CHANGELOG.rst

    There were no breaking changes mentioned in the changelog only bug fixes

4. additional research
    https://github.com/conda-forge/pep8-naming-feedstock/issues

    There were no open issues mentioned in conda-forge at the time of the review 

5. verify dev_url
    https://github.com/PyCQA/pep8-naming

6. verify doc_url
   https://pypi.org/project/pep8-naming/

7. verify that pip is in the test section
8. veriy the test section
9. additional tests

In order to test the `pep8-naming` package version `0.12.1` the folowing
command was used:
`conda build pep8-naming-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `pep8-naming` to version `0.12.1`
