### PR TITLE
Update pep8-naming to version 0.12.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  # skip: True  # [py<36]
-  # noarch: python
+  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   number: 0
 
@@ -32,7 +31,7 @@ test:
   imports:
     - pep8ext_naming
   requires:
-    #  - python <3.10
+    - python <3.10
     - pip
   commands:
     - pip check


### PR DESCRIPTION
`pep8-naming` version `0.12.1`

check the upstream
https://github.com/PyCQA/pep8-naming/tree/0.12.1

check the pinnings
https://github.com/PyCQA/pep8-naming/blob/0.12.1/tox.ini
https://github.com/PyCQA/pep8-naming/blob/0.12.1/setup.py
https://github.com/PyCQA/pep8-naming/blob/0.12.1/setup.cfg
https://github.com/PyCQA/pep8-naming/blob/0.12.1/run_tests.py

check the changelogs
https://github.com/PyCQA/pep8-naming/blob/0.12.1/CHANGELOG.rst

There were no breaking changes mentioned in the changelog only bug fixes

additional research
https://github.com/conda-forge/pep8-naming-feedstock/issues

There were no open issues mentioned in conda-forge at the time of the review

verify dev_url
https://github.com/PyCQA/pep8-naming

verify doc_url
https://pypi.org/project/pep8-naming/

verify that pip is in the test section

veriy the test section

corrected python pinnings 

additional tests

In order to test the pep8-naming package version 0.12.1 the folowing
command was used:
`conda build pep8-naming-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `pep8-naming` to version `0.12.1`

a